### PR TITLE
cicd audit

### DIFF
--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -3,6 +3,10 @@ name: CI Testing
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -20,8 +20,11 @@ jobs:
       - name: Lint frontend
         run: npm run -w packages/travel-project-frontend lint
 
+      - name: Build frontend
+        run: npm run -w packages/travel-project-frontend build
+
       - name: Lint backend
         run: npm run -w packages/travel-project-backend lint
 
-      - name: Build project
-        run: npm run -w packages/travel-project-frontend build
+      - name: Build backend
+        run:  npm run -w packages/travel-project-backend build

--- a/.github/workflows/main_travel-hub.yml
+++ b/.github/workflows/main_travel-hub.yml
@@ -23,10 +23,7 @@ jobs:
 
       - name: npm install, build, and test
         run: |
-          cp ../../prisma/schema.prisma prisma/schema.prisma
-          cp envs/prod.env .env
           npm install --workspaces=false
-          npx prisma generate
           npm run build --if-present
           npm run test --if-present
         working-directory: packages/travel-project-backend

--- a/.github/workflows/main_travel-hub.yml
+++ b/.github/workflows/main_travel-hub.yml
@@ -27,7 +27,6 @@ jobs:
 
       - name: npm install, build, and test
         run: |
-          rm -r node_modules
           npm install --workspaces=false
           npm run build --if-present
           npm run test --if-present

--- a/.github/workflows/main_travel-hub.yml
+++ b/.github/workflows/main_travel-hub.yml
@@ -23,7 +23,10 @@ jobs:
 
       - name: npm install, build, and test
         run: |
+          cp ../../prisma/schema.prisma prisma/schema.prisma
+          cp envs/prod.env .env
           npm install --workspaces=false
+          npx prisma generate
           npm run build --if-present
           npm run test --if-present
         working-directory: packages/travel-project-backend

--- a/.github/workflows/main_travel-hub.yml
+++ b/.github/workflows/main_travel-hub.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -39,6 +43,7 @@ jobs:
           path: packages/travel-project-backend/release.zip
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build
     environment:

--- a/.github/workflows/main_travel-hub.yml
+++ b/.github/workflows/main_travel-hub.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: npm install, build, and test
         run: |
+          rm -r node_modules
           npm install --workspaces=false
           npm run build --if-present
           npm run test --if-present

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 .DS_Store
-dist
 .env
 .idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -17791,6 +17791,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-promise": "^6.1.1",
         "prettier": "^3.0.3",
+        "prisma": "^5.6.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       }
@@ -17851,6 +17852,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-promise": "^6.1.1",
         "prettier": "^3.0.3",
+        "prisma": "^5.6.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "packages/*"
       ],
       "dependencies": {
-        "@prisma/client": "^5.5.2",
+        "@prisma/client": "^5.6.0",
         "react-router-dom": "^6.18.0"
       },
       "devDependencies": {
-        "prisma": "^5.5.2"
+        "prisma": "^5.6.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17791,7 +17791,6 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-promise": "^6.1.1",
         "prettier": "^3.0.3",
-        "prisma": "^5.6.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       }
@@ -17852,7 +17851,6 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-promise": "^6.1.1",
         "prettier": "^3.0.3",
-        "prisma": "^5.6.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "packages/*"
   ],
   "devDependencies": {
-    "prisma": "^5.5.2"
+    "prisma": "^5.6.0"
   },
   "dependencies": {
-    "@prisma/client": "^5.5.2",
+    "@prisma/client": "^5.6.0",
     "react-router-dom": "^6.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "npx prisma format",
     "validate": "npx prisma validate",
     "start": "cd packages/travel-project-frontend && npm start",
-    "serve": "cd packages/travel-project-backend && npm start",
+    "serve": "cd packages/travel-project-backend && npm run serve",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/packages/travel-project-backend/.gitignore
+++ b/packages/travel-project-backend/.gitignore
@@ -1,0 +1,2 @@
+dist
+schema.prisma

--- a/packages/travel-project-backend/envs/prod.env
+++ b/packages/travel-project-backend/envs/prod.env
@@ -1,0 +1,7 @@
+ENV=prod
+
+DATABASE_URL='mysql://tr1foqy9yr6gojjbtdu0:pscale_pw_PBByaL1O7thc57xRCrlXFbt19nxoqXRo1RVD7Q290O8@aws.connect.psdb.cloud/307-travel-project?sslaccept=strict'
+
+TOKEN_SECRET='3608711b89134c2c078b76f47927d6bafb938f428238578ab1adc4a2a034b0b9'
+
+PORT=8000

--- a/packages/travel-project-backend/package.json
+++ b/packages/travel-project-backend/package.json
@@ -5,8 +5,10 @@
   "scripts": {
     "setup": "cp envs/dev.env .env",
     "lint": "eslint . --fix",
-    "start": "ts-node src/index.ts",
-    "build": "tsc"
+    "serve": "ts-node src/index.ts",
+    "build": "tsc",
+    "start": "npm run build && node dist/index.js",
+    "test": "echo \"placeholder test\""
   },
   "author": "Seamus O'Malley",
   "license": "ISC",
@@ -31,6 +33,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-promise": "^6.1.1",
     "prettier": "^3.0.3",
+    "prisma": "^5.6.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   }

--- a/packages/travel-project-backend/package.json
+++ b/packages/travel-project-backend/package.json
@@ -34,7 +34,6 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-promise": "^6.1.1",
     "prettier": "^3.0.3",
-    "prisma": "^5.6.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   }

--- a/packages/travel-project-backend/package.json
+++ b/packages/travel-project-backend/package.json
@@ -6,7 +6,7 @@
     "setup": "cp envs/dev.env .env",
     "lint": "eslint . --fix",
     "serve": "ts-node src/index.ts",
-    "prebuild": "cp ../../prisma/schema.prisma schema.prisma && npx prisma generate --binaryTargets=native,debian-openssl-1.1.x && cp envs/prod.env .env",
+    "prebuild": "cp ../../prisma/schema.prisma schema.prisma && npx prisma generate && cp envs/prod.env .env",
     "build": "tsc",
     "start": "npm run build && node dist/index.js",
     "test": "echo \"placeholder test\""

--- a/packages/travel-project-backend/package.json
+++ b/packages/travel-project-backend/package.json
@@ -6,6 +6,7 @@
     "setup": "cp envs/dev.env .env",
     "lint": "eslint . --fix",
     "serve": "ts-node src/index.ts",
+    "prebuild": "cp ../../prisma/schema.prisma schema.prisma && npx prisma generate && cp envs/prod.env .env",
     "build": "tsc",
     "start": "npm run build && node dist/index.js",
     "test": "echo \"placeholder test\""

--- a/packages/travel-project-backend/package.json
+++ b/packages/travel-project-backend/package.json
@@ -6,7 +6,7 @@
     "setup": "cp envs/dev.env .env",
     "lint": "eslint . --fix",
     "serve": "ts-node src/index.ts",
-    "prebuild": "cp ../../prisma/schema.prisma schema.prisma && npx prisma generate && cp envs/prod.env .env",
+    "prebuild": "cp ../../prisma/schema.prisma schema.prisma && npx prisma generate --binaryTargets=native,debian-openssl-1.1.x && cp envs/prod.env .env",
     "build": "tsc",
     "start": "npm run build && node dist/index.js",
     "test": "echo \"placeholder test\""

--- a/packages/travel-project-frontend/.gitignore
+++ b/packages/travel-project-frontend/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+schema.prisma

--- a/packages/travel-project-frontend/envs/prod.env
+++ b/packages/travel-project-frontend/envs/prod.env
@@ -1,1 +1,3 @@
 ENV=prod
+
+REACT_APP_API_URL='travel-hub.azurewebsites.net'

--- a/packages/travel-project-frontend/package.json
+++ b/packages/travel-project-frontend/package.json
@@ -32,7 +32,6 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-promise": "^6.1.1",
     "prettier": "^3.0.3",
-    "prisma": "^5.6.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },

--- a/packages/travel-project-frontend/package.json
+++ b/packages/travel-project-frontend/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-promise": "^6.1.1",
     "prettier": "^3.0.3",
+    "prisma": "^5.6.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },

--- a/packages/travel-project-frontend/package.json
+++ b/packages/travel-project-frontend/package.json
@@ -40,6 +40,7 @@
     "setup": "cp envs/dev.env .env",
     "lint": "eslint . --fix",
     "start": "react-scripts start",
+    "prebuild": "cp ../../prisma/schema.prisma schema.prisma && prisma generate && cp envs/prod.env .env",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/packages/travel-project-frontend/package.json
+++ b/packages/travel-project-frontend/package.json
@@ -39,7 +39,7 @@
     "setup": "cp envs/dev.env .env",
     "lint": "eslint . --fix",
     "start": "react-scripts start",
-    "prebuild": "cp ../../prisma/schema.prisma schema.prisma && prisma generate && cp envs/prod.env .env",
+    "prebuild": "cp ../../prisma/schema.prisma schema.prisma && npx prisma generate && cp envs/prod.env .env",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-1.1.x"]
 }
 
 datasource db {


### PR DESCRIPTION
- make ci and backend cd build step happen on PR
- add prod.env
- add prebuild scripts to copy .env files and to copy down and generate prisma client
- fix schema.prisma to run on azure functions: https://www.prisma.io/docs/guides/deployment/serverless/deploy-to-azure-functions#summary 

NOTE: be sure to rerun the npm run setup command after this is merged and you pull into local (it is really best practice to run this anytime you pull the latest)

TODO: before presentation, swap out prod.env database_url for prod database